### PR TITLE
fix double slash in topics and tags links

### DIFF
--- a/layouts/partials/details.html
+++ b/layouts/partials/details.html
@@ -7,12 +7,12 @@
         </section>
         <ul id="categories">
           {{ range .Params.topics }}
-            <li><a href="{{ $baseurl }}/topics/{{ . | urlize }}">{{ . }}</a> </li>
+            <li><a href="{{ $baseurl }}topics/{{ . | urlize }}">{{ . }}</a> </li>
           {{ end }}
         </ul>
         <ul id="tags">
           {{ range .Params.tags }}
-            <li> <a href="{{ $baseurl }}/tags/{{ . | urlize }}">{{ . }}</a> </li>
+            <li> <a href="{{ $baseurl }}tags/{{ . | urlize }}">{{ . }}</a> </li>
           {{ end }}
         </ul>
     </div>


### PR DESCRIPTION
Since `$baseurl` is defined in config with the trailing slash (i.e., https://github.com/spf13/spf13.com/blob/master/config.toml#L1), the `href` here doesn't need the slash preceding `topics` and `tags`